### PR TITLE
Bump nanoid from 3.3.16 to 3.3.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4976,9 +4976,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes CVE-2026-67213 (HIGH): nanoid before 3.3.17 contains an infinite loop in customAlphabet when the generated size is zero.

nanoid is a transitive dependency via postcss@8.5.25, which requires "^3.3.16". Since 3.3.17 satisfies that range, this is a lock-file-only change with no manifest edit needed.

This also unblocks the Lint workflow, which was failing because Super-Linter's Trivy step flagged the CVE in package-lock.json.